### PR TITLE
Change from flex to absolute position

### DIFF
--- a/Packages/com.bitbebop.ui-toolkit-safe-area/Runtime/SafeArea.cs
+++ b/Packages/com.bitbebop.ui-toolkit-safe-area/Runtime/SafeArea.cs
@@ -38,8 +38,13 @@ namespace Bitbebop
 
         public SafeArea()
         {
-            style.flexGrow = 1;
-            style.flexShrink = 0;
+            // By using absolute position to fill the entire screen area, instead of setting flex grow,
+            // SafeArea containers can be stacked.
+            style.position = Position.Absolute;
+            style.top = 0;
+            style.bottom = 0;
+            style.left = 0;
+            style.right = 0;
             
             _contentContainer = new VisualElement();
             _contentContainer.name = "safe-area-content-container";


### PR DESCRIPTION
By using absolute position instead of flex to fill the entire screen, multiple SafeArea containers can be added to the hierarchy and stacked.

This will be useful when more planned options are added, to have different SafeArea rules for different containers in the same document.