### PR TITLE
Exclude SafeArea on tvOS

### DIFF
--- a/Packages/com.bitbebop.ui-toolkit-safe-area/Runtime/SafeArea.cs
+++ b/Packages/com.bitbebop.ui-toolkit-safe-area/Runtime/SafeArea.cs
@@ -113,6 +113,11 @@ namespace Bitbebop
             var leftTop = RuntimePanelUtils.ScreenToPanel(panel, new Vector2(safeArea.xMin, Screen.height - safeArea.yMax));
             var rightBottom = RuntimePanelUtils.ScreenToPanel(panel, new Vector2(Screen.width - safeArea.xMax, safeArea.yMin));
 
+#if UNITY_TVOS
+            if (ExcludeTvos)
+                return new Offset { Left = 0, Right = 0, Top = 0, Bottom = 0 };
+#endif
+
             // If the user has flagged an edge as excluded, set that edge to 0.
             return new Offset()
             {

--- a/Packages/com.bitbebop.ui-toolkit-safe-area/Runtime/SafeArea.cs
+++ b/Packages/com.bitbebop.ui-toolkit-safe-area/Runtime/SafeArea.cs
@@ -26,6 +26,7 @@ namespace Bitbebop
         public bool ExcludeRight { get; set; }
         public bool ExcludeTop { get; set; }
         public bool ExcludeBottom { get; set; }
+        public bool ExcludeTvos { get; set; }
 
         public new class UxmlTraits : VisualElement.UxmlTraits
         {
@@ -34,6 +35,7 @@ namespace Bitbebop
             private UxmlBoolAttributeDescription _excludeRightAttr = new() { name = "exclude-right", defaultValue = false };
             private UxmlBoolAttributeDescription _excludeTopAttr = new() { name = "exclude-top", defaultValue = false };
             private UxmlBoolAttributeDescription _excludeBottomAttr = new() { name = "exclude-bottom", defaultValue = false };
+            private UxmlBoolAttributeDescription _excludeTvosAttr = new() { name = "exclude-tvos", defaultValue = false };
 
             public override IEnumerable<UxmlChildElementDescription> uxmlChildElementsDescription
             {
@@ -50,6 +52,7 @@ namespace Bitbebop
                 ate.ExcludeRight = _excludeRightAttr.GetValueFromBag(bag, cc);
                 ate.ExcludeTop = _excludeTopAttr.GetValueFromBag(bag, cc);
                 ate.ExcludeBottom = _excludeBottomAttr.GetValueFromBag(bag, cc);
+                ate.ExcludeTvos = _excludeTvosAttr.GetValueFromBag(bag, cc);
             }
         }
 


### PR DESCRIPTION
Add an option to exclude SafeArea for all edges on tvOS.