### PR TITLE
Add PickingMode.Ignore to SafeArea VisualElements #8

### DIFF
--- a/Packages/com.bitbebop.ui-toolkit-safe-area/Runtime/SafeArea.cs
+++ b/Packages/com.bitbebop.ui-toolkit-safe-area/Runtime/SafeArea.cs
@@ -69,9 +69,11 @@ namespace Bitbebop
             style.bottom = 0;
             style.left = 0;
             style.right = 0;
+            pickingMode = PickingMode.Ignore;
             
             _contentContainer = new VisualElement();
             _contentContainer.name = "safe-area-content-container";
+            _contentContainer.pickingMode = PickingMode.Ignore;
             _contentContainer.style.flexGrow = 1;
             _contentContainer.style.flexShrink = 0;
             hierarchy.Add(_contentContainer);


### PR DESCRIPTION
Fixes #8 . Ignores catching input by SafeArea containers. (doesn't affect its children)