### PR TITLE
add schedule to listen for portrait/portrait and landscape/landscape …

### DIFF
--- a/Packages/com.bitbebop.ui-toolkit-safe-area/Runtime/SafeArea.cs
+++ b/Packages/com.bitbebop.ui-toolkit-safe-area/Runtime/SafeArea.cs
@@ -61,6 +61,8 @@ namespace Bitbebop
             get => _contentContainer;
         }
 
+        private ScreenOrientation screenOrientation;
+
         public SafeArea()
         {
             // By using absolute position instead of flex to fill the full screen, SafeArea containers can be stacked.
@@ -79,6 +81,16 @@ namespace Bitbebop
             hierarchy.Add(_contentContainer);
 
             RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+
+            schedule.Execute(() =>
+            {
+                // Check if there is a portrait up/down (3) or landscape left/right (7) change.
+                if (((int) screenOrientation ^ (int) Screen.orientation) is 3 or 7)
+                {
+                    screenOrientation = Screen.orientation;
+                    OnGeometryChanged(null);
+                }
+            }).Every(1000 / Application.targetFrameRate);
         }
 
         private void OnGeometryChanged(GeometryChangedEvent evt)

--- a/Packages/com.bitbebop.ui-toolkit-safe-area/Runtime/SafeArea.cs
+++ b/Packages/com.bitbebop.ui-toolkit-safe-area/Runtime/SafeArea.cs
@@ -86,10 +86,9 @@ namespace Bitbebop
             {
                 // Check if there is a portrait up/down (3) or landscape left/right (7) change.
                 if (((int) screenOrientation ^ (int) Screen.orientation) is 3 or 7)
-                {
-                    screenOrientation = Screen.orientation;
                     OnGeometryChanged(null);
-                }
+
+                screenOrientation = Screen.orientation;
             }).Every(1000 / Application.targetFrameRate);
         }
 


### PR DESCRIPTION
We noticed that there is no UI update when changing from landscape left to right mode. That bothered us since there is a notch on most of the phones on top, so we had inconsistent button placement when doing direct switches without going via portrait.

For us it works now, but feel free to adapt the code in your own style.
Maybe there is a better solution then doing it on a schedule, but I could not find an event to register for. I guess it's fine to run every frame, since most of the time it's just a single numerical evaluation.